### PR TITLE
Changes to VS 2022 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ CMakeCache.txt
 CTestTestfile.cmake
 h264p/cmake_install.cmake
 libh264p/cmake_install.cmake
+/h264p/h264p.dir/Release
+/Testing/Temporary
+/install_manifest.txt

--- a/libh264p/CMakeLists.txt
+++ b/libh264p/CMakeLists.txt
@@ -21,9 +21,7 @@ else()
         OUTPUT_NAME h264p)
 endif()
 
-if(CMAKE_VS_PLATFORM_NAME)
-include_directories(../../../3rdParty/loki/include)
-elseif(WIN32)
+if(WIN32)
 include_directories(../../loki-lib/include)
 else()
 target_include_directories(libh264p 


### PR DESCRIPTION
Updated ignore and CMakeList.txt file to build using VS 2022.