### PR TITLE
NAL Unit Changes

### DIFF
--- a/libh264p/nalu.cpp
+++ b/libh264p/nalu.cpp
@@ -37,7 +37,7 @@ public:
 	{
 		if (!_rbsp.empty())
 		{
-			unsigned char t = _rbsp[0] & 0x1F;
+			uint8_t t = _rbsp[0] & 0x1F;
 			_nal_ref_idc = _rbsp[0] & 0x60;
 
 			switch (t)
@@ -90,7 +90,7 @@ public:
 	std::shared_ptr<NALUnitImpl> _pimpl;
 	NALUnit::RawByteStreamPayload _rbsp;
 	unsigned short _startcodeprefix_len;
-	char _nal_ref_idc{};
+	uint8_t _nal_ref_idc{};
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -140,7 +140,7 @@ unsigned int NALUnit::size() const
 	return (unsigned int)_pimpl->_rbsp.size();
 }
 
-void NALUnit::push_back(char c)
+void NALUnit::push_back(uint8_t c)
 {
 	_pimpl->_rbsp.push_back(c);
 }
@@ -160,12 +160,17 @@ NALUnit::iterator ThetaStream::NALUnit::end()
 	return _pimpl->_rbsp.end();
 }
 
+const uint8_t* ThetaStream::NALUnit::data() const
+{
+	return _pimpl->_rbsp.data();
+}
+
 unsigned short NALUnit::startcodeprefix_len() const
 {
 	return _pimpl->_startcodeprefix_len;
 }
 
-char NALUnit::nal_ref_idc() const
+uint8_t NALUnit::nal_ref_idc() const
 {
 	return _pimpl->_nal_ref_idc;
 }

--- a/libh264p/nalu.h
+++ b/libh264p/nalu.h
@@ -9,8 +9,6 @@
 namespace ThetaStream
 {
 
-class NALUnitImpl;
-
 /////////////////////////////////////////////////////////////////////////////
 // NALUint
 
@@ -18,7 +16,7 @@ class NALUnit
 	: public Loki::BaseVisitable<>
 {
 public:
-	typedef std::vector<char> RawByteStreamPayload;
+	typedef std::vector<uint8_t> RawByteStreamPayload;
 	typedef RawByteStreamPayload::iterator iterator;
 	typedef RawByteStreamPayload::const_iterator const_iterator;
 public:
@@ -32,14 +30,16 @@ public:
 	NALUnit(NALUnit&& other) noexcept;
 
 	unsigned short startcodeprefix_len() const;
-	char nal_ref_idc() const;
+	uint8_t nal_ref_idc() const;
 
 	unsigned int size() const;
-	void push_back(char c);
+	void push_back(uint8_t c);
 	void parse();
 
 	iterator begin();
 	iterator end();
+
+	const uint8_t* data() const;
 
 	void Accept(Loki::BaseVisitor& visitor); 
 

--- a/libh264p/naluimpl.cpp
+++ b/libh264p/naluimpl.cpp
@@ -13,7 +13,7 @@ using namespace ThetaStream;
 
 
 
-NALUnitImpl::NALUnitImpl(unsigned char nut)
+NALUnitImpl::NALUnitImpl(uint8_t nut)
 	:nal_unit_type(nut)
 {
 

--- a/libh264p/naluimpl.h
+++ b/libh264p/naluimpl.h
@@ -16,10 +16,10 @@ class NALUnitImpl
 	: public Loki::BaseVisitable<>
 {
 public:
-	typedef std::vector<char> RawByteStreamPayload;
+	typedef std::vector<uint8_t> RawByteStreamPayload;
 	typedef RawByteStreamPayload::iterator iterator;
 public:
-	NALUnitImpl(unsigned char nut);
+	NALUnitImpl(uint8_t nut);
 	virtual ~NALUnitImpl();
 
 	virtual void parse(NALUnitImpl::iterator first

--- a/libh264p/pps.cpp
+++ b/libh264p/pps.cpp
@@ -51,7 +51,7 @@ NALUnitPPS::~NALUnitPPS()
 
 void NALUnitPPS::parse(NALUnitImpl::iterator first, NALUnitImpl::iterator last)
 {
-	std::vector<char> sodb;
+	std::vector<uint8_t> sodb;
 	removeEmulationPrevention3Bytes(std::back_inserter(sodb), first, last);
 
 	Bitstream bitstream(++(sodb.begin()), sodb.end(), sodb.size() - 1);

--- a/libh264p/sei.cpp
+++ b/libh264p/sei.cpp
@@ -59,7 +59,7 @@ unsigned int SEI::size() const
 	return (unsigned int)rbsp_.size();
 }
 
-void SEI::push_back(char c)
+void SEI::push_back(uint8_t c)
 {
 	rbsp_.push_back(c);
 }

--- a/libh264p/sei.h
+++ b/libh264p/sei.h
@@ -18,7 +18,7 @@ class SEI
 	: public Loki::BaseVisitable<>
 {
 public:
-	typedef std::vector<char> RawByteStreamPayload;
+	typedef std::vector<uint8_t> RawByteStreamPayload;
 public:
 	SEI();
 	~SEI();
@@ -30,7 +30,7 @@ public:
 	void swap( SEI& src);
 
 	unsigned int size() const;
-	void push_back(char c);
+	void push_back(uint8_t c);
 	void parse();
 
 	void Accept(Loki::BaseVisitor& visitor); 

--- a/libh264p/seiimpl.h
+++ b/libh264p/seiimpl.h
@@ -16,7 +16,7 @@ class SEIimpl
 	: public Loki::BaseVisitable<>
 {
 public:
-	typedef std::vector<char> RawByteStreamPayload;
+	typedef std::vector<uint8_t> RawByteStreamPayload;
 	typedef RawByteStreamPayload::iterator iterator;
 public:
 	SEIimpl();

--- a/libh264p/slice.cpp
+++ b/libh264p/slice.cpp
@@ -53,7 +53,7 @@ NALUnitSliceHeaderImpl::~NALUnitSliceHeaderImpl()
 
 void NALUnitSliceHeaderImpl::parse(NALUnitImpl::iterator first, NALUnitImpl::iterator last)
 {
-	std::vector<char> sodb;
+	std::vector<uint8_t> sodb;
 	removeEmulationPrevention3Bytes(std::back_inserter(sodb), first, last);
 
 	Bitstream bitstream(++(sodb.begin()), sodb.end(), sodb.size() - 1);

--- a/libh264p/sps.cpp
+++ b/libh264p/sps.cpp
@@ -120,7 +120,7 @@ NALUnitSPS::~NALUnitSPS()
 
 void NALUnitSPS::parse(NALUnitImpl::iterator first, NALUnitImpl::iterator last)
 {
-	std::vector<char> sodb;
+	std::vector<uint8_t> sodb;
 	removeEmulationPrevention3Bytes(std::back_inserter(sodb), first, last);
 
 	Bitstream bitstream(++(sodb.begin()), sodb.end(), sodb.size() - 1);


### PR DESCRIPTION
- Added a new member function, data(), that returns the NALUnit's raw byte stream payload. 
- Changed the basic raw byte stream payload type from char to unsigned char.