### PR TITLE
Change input parameters type

### DIFF
--- a/h264p/h264p.cpp
+++ b/h264p/h264p.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
 		return -1;
 	}
 
-	char memblock[N]{};
+	uint8_t memblock[N]{};
 	try
 	{
 		clock_t start, end;

--- a/libh264p/h264prsr.cpp
+++ b/libh264p/h264prsr.cpp
@@ -8,7 +8,7 @@ using namespace std;
 
 namespace
 {
-	int hasStartCode(const char* buf)
+	int hasStartCode(const uint8_t* buf)
 	{
 		if(buf[0] == 0x00
 			&& buf[1] == 0x00
@@ -58,7 +58,7 @@ ThetaStream::H264Parser::~H264Parser()
 }
 
 
-void ThetaStream::H264Parser::parse(const char* buf, unsigned int size)
+void ThetaStream::H264Parser::parse(const uint8_t* buf, size_t size)
 {
 	unsigned short startcodeprefix_len = 0;
 

--- a/libh264p/h264prsr.h
+++ b/libh264p/h264prsr.h
@@ -15,7 +15,7 @@ public:
 	H264Parser();
 	virtual ~H264Parser();
 
-	virtual void parse(const char* buf, unsigned int size);
+	virtual void parse(const uint8_t* buf, size_t size);
 	virtual void onNALUnit( ThetaStream::NALUnit& nalu);
 
 private:


### PR DESCRIPTION
Modified H264Parser::parse function input parameter types to match the implementation type of uint8_t instead of char.