### PR TITLE
Added cstdint for uint8_t support

### DIFF
--- a/h264p/include/h264p/h264prsr.h
+++ b/h264p/include/h264p/h264prsr.h
@@ -2,6 +2,7 @@
 #define H264PRSR_H
 
 #include <memory>
+#include <cstdint>
 
 namespace ThetaStream
 {

--- a/h264p/include/h264p/nalu.h
+++ b/h264p/include/h264p/nalu.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include <loki/Visitor.h>
+#include <cstdint>
 
 namespace ThetaStream
 {

--- a/h264p/include/h264p/sei.h
+++ b/h264p/include/h264p/sei.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include <loki/Visitor.h>
+#include <cstdint>
 
 namespace ThetaStream
 {


### PR DESCRIPTION
With GCC-15 something changed to remove uint8_t from other headers. We have to include <cstdint> to get that back.